### PR TITLE
Stop importing vault items associated with an organization

### DIFF
--- a/core.go
+++ b/core.go
@@ -239,27 +239,30 @@ func RestoreBackupFile(fileName, passphrase, sessionKey string, sleepMillisecond
 		if item.FolderID != nil {
 			*item.FolderID = oldToNewFolderID[*item.FolderID]
 		}
-		item.OrganizationID = nil
-		item.CollectionIDS = nil
+		if item.OrganizationID == nil
+		{
+			// probably not needed
+			item.CollectionIDS = nil
 
-		itemBytes, err = json.Marshal(item)
-		cmd := exec.Command("bw", "create", "item", "--session", sessionKey, b64.StdEncoding.EncodeToString(itemBytes))
-		var stdout bytes.Buffer
-		var stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		cmd.Stdin = os.Stdin
-		if err := cmd.Run(); err != nil {
-			fmt.Println("An error occured: ", err)
-			spew.Dump(stdout, stderr)
+			itemBytes, err = json.Marshal(item)
+			cmd := exec.Command("bw", "create", "item", "--session", sessionKey, b64.StdEncoding.EncodeToString(itemBytes))
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			cmd.Stdin = os.Stdin
+			if err := cmd.Run(); err != nil {
+				fmt.Println("An error occured: ", err)
+				spew.Dump(stdout, stderr)
+			}
+			fmt.Println("restoring item", item.Name)
+			newItem := PortWardenElement{}
+			err = json.Unmarshal(stdout.Bytes(), &newItem)
+			if err != nil {
+				return err
+			}
+			oldToNewItemID[item.ID] = newItem.ID
 		}
-		fmt.Println("restoring item", item.Name)
-		newItem := PortWardenElement{}
-		err = json.Unmarshal(stdout.Bytes(), &newItem)
-		if err != nil {
-			return err
-		}
-		oldToNewItemID[item.ID] = newItem.ID
 	}
 	fmt.Println("restoring item finished")
 


### PR DESCRIPTION
I don't have time to test this right now, but I wanted to throw it up as a possible suggestion. Currently, portwarden imports all vault items, including items associated with an organization. During the import, the organization(s) and collection(s) are erased and the item is imported as an orphaned item associated with the personal vault.

However, Bitwarden allows exporting all items associated with a given organization. I followed the following procedure:
1. Export from Bitwarden personal vault via portwarden
2. Export from Bitwarden organization vault via unencrypted JSON
3. Import into vaultwarden personal vault via portwarden
4. Import into vaultwarden organization vault via unencrypted JSON

This worked very well, but I ended up with duplicate entries because the organization vault items were imported by portwarden as ophaned entries. This PR should allow the process above to work, minus the duplicate orphaned entries.

In a perfect world, portwarden would handle creating the organization(s) and collection(s) - same as folders are already handled - but it looks like these commands aren't available in the Bitwarden CLI.

If given a build, I can test this PR. If it works as expected, I can update the Readme file with details about how Organizations/Collections can be handled with existing Bitwarden export/import tools.