### PR TITLE
Fixed typo in restore command description.

### DIFF
--- a/cmd/portwarden/portwarden.go
+++ b/cmd/portwarden/portwarden.go
@@ -100,7 +100,7 @@ func main() {
 		{
 			Name:    "restore",
 			Aliases: []string{"d"},
-			Usage:   "restore a `.portwarden` backgup to a Bitwarden Account",
+			Usage:   "restore a `.portwarden` backup to a Bitwarden Account",
 			Action: func(c *cli.Context) error {
 				if len(passphrase) == 0 {
 					return errors.New(ErrNoPhassPhraseProvided)


### PR DESCRIPTION
Just a small fix for a typo I noticed in the usage output.