### PR TITLE
Get BW_SESSION from environment if possible

### DIFF
--- a/types.go
+++ b/types.go
@@ -75,6 +75,14 @@ type Login struct {
 	PasswordRevisionDate *string `json:"passwordRevisionDate"`
 }
 
+type Status struct {
+	ServerUrl string `json:"serverUrl"`
+	LastSync  string `json:"lastSync"`
+	UserEmail string `json:"userEmail"`
+	UserId    string `json:"userId"`
+	Status    string `json:"status"`
+}
+
 type Uris struct {
 	Match interface{} `json:"match"`
 	URI   string      `json:"uri"`


### PR DESCRIPTION
Portwarden gets bw session always by user inputing master password. It works fine but is not possible to export items automatically by scirpts.

I change the process of getting bw session. First check bw status. If already `unlock`, get bw session from environment directly instead of requiring master password.